### PR TITLE
seatd required to build package

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,7 +27,7 @@ exit_cleanup() {
 }
 
 makedepends=('git' 'meson' 'ninja' 'cmake' 'pixman' 'pkgconf' 'vulkan-headers' 'wayland-protocols>=1.17')
-depends=(wayland opengl-driver xorg-server-xwayland libdrm libinput libxkbcommon libxcomposite libcap libxcb libpng glslang libxrender libxtst libxres vulkan-icd-loader sdl2 xcb-util-wm)
+depends=(wayland opengl-driver xorg-server-xwayland libdrm libinput libxkbcommon libxcomposite libcap libxcb libpng glslang libxrender libxtst libxres vulkan-icd-loader sdl2 xcb-util-wm seatd)
 conflicts=('gamescope')
 
 # custom commit to pass to git


### PR DESCRIPTION
Fails to build without this:

```
wlroots| Run-time dependency libseat found: NO (tried pkgconfig and cmake)                                                                  
wlroots| Looking for a fallback subproject for the dependency libseat                                                                       

subprojects/wlroots/backend/session/meson.build:1:0: ERROR: Neither a subproject directory nor a seatd.wrap file was found.

A full log can be found at /home/vash/work/PKGBUILDS/gamescope-git/src/_build/meson-logs/meson-log.txt
==> ERROR: A failure occurred in build().
    Aborting...
  -> Cleanup done
```